### PR TITLE
Update Matomo version to lastest 3.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     networks:
     - back
   app:
-    image: matomo:3.5.0-fpm
+    image: matomo:3.14-fpm
     links:
       - db
     volumes:


### PR DESCRIPTION
Set version to 3.14, the one we're currently using in production.

This is a preparation for https://phabricator.wikimedia.org/T272155